### PR TITLE
qrb_ros_color_space_convert: fix fps issue when 1080p@60

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ ssh root@[ip-addr]
 (ssh) export FASTRTPS_DEFAULT_PROFILES_FILE=/opt/qcom/qirp-sdk/usr/share/qrb_ros_colorspace_convert/config/large_message_profile.xml
 ```
 
-regarding the large_message_profile.xml, you can resize the segment_size of large_message_profile.xml for your project requirement.
+You can resize the segment_size of large_message_profile.xml for your project requirement.
 
 Run the ROS2 package.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ Currently, we only support two color space format: NV12 and RGB888.
 ssh root@[ip-addr]
 (ssh) export XDG_RUNTIME_DIR=/dev/socket/weston/
 (ssh) export WAYLAND_DISPLAY=wayland-1
+(ssh) export FASTRTPS_DEFAULT_PROFILES_FILE=/opt/qcom/qirp-sdk/usr/share/qrb_ros_colorspace_convert/config/large_message_profile.xml
 ```
+
+regarding the large_message_profile.xml, you can resize the segment_size of large_message_profile.xml for your project requirement.
 
 Run the ROS2 package.
 

--- a/qrb_ros_colorspace_convert/CMakeLists.txt
+++ b/qrb_ros_colorspace_convert/CMakeLists.txt
@@ -18,4 +18,4 @@ rclcpp_components_register_nodes(${PROJECT_NAME}
   "qrb_ros::colorspace_convert::ColorspaceConvertNode"
 )
 
-ament_auto_package(INSTALL_TO_SHARE launch)
+ament_auto_package(INSTALL_TO_SHARE launch config)


### PR DESCRIPTION
- Enable SHM transport manually
- Set segment_size as 32M for large size image message