### PR TITLE
qrb_ros_colorspace_convert: fix fps issue when 1080p@60

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ Currently, we only support two color space format: NV12 and RGB888.
 ssh root@[ip-addr]
 (ssh) export XDG_RUNTIME_DIR=/dev/socket/weston/
 (ssh) export WAYLAND_DISPLAY=wayland-1
+(ssh) export FASTRTPS_DEFAULT_PROFILES_FILE=/opt/qcom/qirp-sdk/usr/share/qrb_ros_colorspace_convert/config/large_message_profile.xml
 ```
+
+You can resize the segment_size of large_message_profile.xml for your project requirement.
 
 Run the ROS2 package.
 

--- a/qrb_colorspace_convert_lib/CMakeLists.txt
+++ b/qrb_colorspace_convert_lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(qrb_colorspace_convert_lib)
+project(qrb_colorspace_convert_lib VERSION 1.0.0)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -19,5 +19,7 @@ target_link_libraries(${PROJECT_NAME}
   EGL
   GLESv2
 )
+
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION 1)
 
 ament_auto_package()

--- a/qrb_ros_colorspace_convert/CMakeLists.txt
+++ b/qrb_ros_colorspace_convert/CMakeLists.txt
@@ -18,4 +18,4 @@ rclcpp_components_register_nodes(${PROJECT_NAME}
   "qrb_ros::colorspace_convert::ColorspaceConvertNode"
 )
 
-ament_auto_package(INSTALL_TO_SHARE launch)
+ament_auto_package(INSTALL_TO_SHARE launch config)


### PR DESCRIPTION
- Enable SHM transport manually
- Set segment_size as 32M for large size image message
- add the use method on readme
- add the compile method on Cmakelist